### PR TITLE
Solve "Does not run in Docker anymore" #2

### DIFF
--- a/repl/views.py
+++ b/repl/views.py
@@ -49,7 +49,6 @@ def verify_token(token):
 
 
 @app.route("/repl", methods=["POST"])
-@auth.login_required
 def repl():
     """
     API that interacts with a REPL session using the given token and some input
@@ -61,6 +60,10 @@ def repl():
     code = request.get_json()["code"]
     # Taking the token should be safe since the token was verified by auth.
     token = request.headers.get("Authorization")[7:]
+    
+    if not verify_token(token):
+        return auth_error(401)
+    
     session = sessions.get(token)
 
     if session.is_active():

--- a/repl/views.py
+++ b/repl/views.py
@@ -58,9 +58,11 @@ def repl():
     line and the result from before.
     """
     code = request.get_json()["code"]
-    # Taking the token should be safe since the token was verified by auth.
-    token = request.headers.get("Authorization")[7:]
     
+    authorization = request.headers.get("Authorization")
+    if authorization is None:
+        return auth_error(401)
+    token = authorization[7:]
     if not verify_token(token):
         return auth_error(401)
     

--- a/repl/views.py
+++ b/repl/views.py
@@ -58,14 +58,14 @@ def repl():
     line and the result from before.
     """
     code = request.get_json()["code"]
-    
+
     authorization = request.headers.get("Authorization")
     if authorization is None:
         return auth_error(401)
     token = authorization[7:]
     if not verify_token(token):
         return auth_error(401)
-    
+
     session = sessions.get(token)
 
     if session.is_active():


### PR DESCRIPTION
I don't know if this is the best approach, but removing `@auth.login_required` from
```python
@app.route("/repl", methods=["POST"])
@auth.login_required
def repl():
```
and instead just manually checking the token as such:
```python
@app.route("/repl", methods=["POST"])
def repl():
    authorization = request.headers.get("Authorization")
    if authorization is None:
        return auth_error(401)
    token = authorization[7:]
    if not verify_token(token):
        return auth_error(401)
    
```
seems to work for me without any issues.